### PR TITLE
Use rel="noopener noreferrer" if link has target="_blank"

### DIFF
--- a/source/cookies.js
+++ b/source/cookies.js
@@ -92,6 +92,7 @@
 		a.addEventListener(click, function(){ invokeEvent('open-more'); });
 		if(config.options.popupMore) {
 			a.setAttribute('target', '_blank');
+			a.setAttribute('rel', 'noopener noreferrer');
 		}
 	}
 


### PR DESCRIPTION
Používání `target="_blank"` otevírá možnost potenciálnímu útoku. Ačkoliv je od Googlu asi nepravděpodobný, používání `rel="noopener noreferrer"` je jednoduchá prevence a dobrá praxe.

Zdroj a odůvodnění (en): https://mathiasbynens.github.io/rel-noopener/